### PR TITLE
psych upgrade for safe_load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 mkmf.log
 *.gem
 .byebug_history
+/vendor/

--- a/confg.gemspec
+++ b/confg.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
 end

--- a/lib/confg/configuration.rb
+++ b/lib/confg/configuration.rb
@@ -84,7 +84,7 @@ module Confg
       ctxt = ::Confg::ErbContext.new
       raw_content = ::File.read(found_path)
       erb_content = ctxt.evaluate(raw_content)
-      yaml_content = ::YAML.send :load, erb_content
+      yaml_content = ::YAML.send :safe_load, erb_content, aliases: true # due to shared sections
 
       unless ignore_env
         yaml_content = yaml_content[confg_env] if confg_env && yaml_content.is_a?(::Hash) && yaml_content.key?(confg_env)

--- a/lib/confg/version.rb
+++ b/lib/confg/version.rb
@@ -2,6 +2,6 @@
 
 module Confg
 
-  VERSION = "2.1.0"
+  VERSION = "2.1.1.rc1"
 
 end


### PR DESCRIPTION
- safe_load support for confg
- bump to RC and lock in deps less

See https://www.ctrl.blog/entry/ruby-psych4.html  for Psych changes

Needed as IRB now depends on RDOC explicitly which brings in a newer psych: https://github.com/ruby/irb/blob/4dffbb1dd391864202d5487431764fc1c497fbec/irb.gemspec#L45
