### PR TITLE
chore(infra): include Gemfile.lock for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /doc/
 /pkg/
 /spec/reports/
-/Gemfile.lock
 /tmp/
 *.bundle
 *.so

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,25 @@
+PATH
+  remote: .
+  specs:
+    confg (3.2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    byebug (12.0.0)
+    minitest (5.25.5)
+    rake (13.3.0)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  bundler
+  byebug
+  confg!
+  minitest (~> 5.0)
+  rake
+
+BUNDLED WITH
+   2.7.1


### PR DESCRIPTION
note: this is not in the compiled binary, but having the lock so install runs and we can ensure installers grab latest if security fixes