### PR TITLE
Drop Ruby 3.2 from CI test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [3.2, 3.3, 3.4]
+        ruby-version: [3.3, 3.4]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    confg (3.3.1)
+    confg (3.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -31,7 +31,7 @@ DEPENDENCIES
 
 CHECKSUMS
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
-  confg (3.3.1)
+  confg (3.4.0)
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   minitest (6.0.3) sha256=88ac8a1de36c00692420e7cb3cc11a0773bbcb126aee1c249f320160a7d11411

--- a/confg.gemspec
+++ b/confg.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 6.0"
   spec.add_development_dependency "rake"
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 end

--- a/lib/confg/version.rb
+++ b/lib/confg/version.rb
@@ -3,8 +3,8 @@
 module Confg
 
   MAJOR       = 3
-  MINOR       = 3
-  PATCH       = 1
+  MINOR       = 4
+  PATCH       = 0
   PRERELEASE  = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRERELEASE].compact.join(".")


### PR DESCRIPTION
Remove Ruby 3.2 from CI test matrix, bump minor version.

Ruby 3.2 EOL prep — aligning CI matrix with supported versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI configuration and gem metadata/versioning, with no runtime logic modifications.
> 
> **Overview**
> Drops Ruby `3.2` from the GitHub Actions test matrix, leaving CI to run on Ruby `3.3` and `3.4` only.
> 
> Bumps the gem to `3.4.0` and updates `confg.gemspec` to require Ruby `>= 3.3.0`, with corresponding `Gemfile.lock` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc3df37fbfa03b82022af4d44352b63da7578a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->