### PR TITLE
chore: gemspec cleanup — metadata, v3.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    confg (3.4.0)
+    confg (3.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -32,7 +32,7 @@ DEPENDENCIES
 CHECKSUMS
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
-  confg (3.4.0)
+  confg (3.4.1)
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1

--- a/confg.gemspec
+++ b/confg.gemspec
@@ -11,22 +11,27 @@ Gem::Specification.new do |spec|
   spec.email         = ["mike@mnelson.io"]
   spec.description   = "Config the pipes"
   spec.summary       = "Sets shared variables for applications"
-  spec.homepage      = "https://github.com/guideline-tech/confg"
   spec.license       = "MIT"
+  spec.required_ruby_version = ">= 3.3.0"
 
-  # Specify which files should be added to the gem when it is released.
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
+
+  github_uri = "https://github.com/guideline-tech/confg"
+
+  spec.homepage = github_uri
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = github_uri
+  spec.metadata["changelog_uri"] = "#{github_uri}/releases"
+  spec.metadata["github_repo"] = github_uri
+  spec.metadata["rubygems_mfa_required"] = "true"
+
   spec.files = Dir["lib/**/*"] + Dir["*.gemspec"]
 
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.metadata["allowed_push_host"] = "https://rubygems.org"
-  spec.metadata["rubygems_mfa_required"] = "true"
-
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "minitest", "~> 6.0"
   spec.add_development_dependency "rake"
-
-  spec.required_ruby_version = ">= 3.3.0"
 end

--- a/lib/confg/version.rb
+++ b/lib/confg/version.rb
@@ -4,7 +4,7 @@ module Confg
 
   MAJOR       = 3
   MINOR       = 4
-  PATCH       = 0
+  PATCH       = 1
   PRERELEASE  = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRERELEASE].compact.join(".")


### PR DESCRIPTION
## Summary

- **`github_uri` constant**: adds `homepage_uri`, `source_code_uri`, `changelog_uri` (releases page), `github_repo`
- No dependency changes
- **Version**: 3.4.0 → 3.4.1 (patch bump)
- **`bundle update`**: Gemfile.lock refreshed

A new release will be kicked once merged.