### PR TITLE
Add missing require for pathname

### DIFF
--- a/lib/confg.rb
+++ b/lib/confg.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 require "confg/version"
 require "confg/configuration"
 require "confg/erb_context"

--- a/lib/confg/configuration.rb
+++ b/lib/confg/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "pathname"
 require "yaml"
 
 module Confg


### PR DESCRIPTION
## Findings

Audited every `require`/`require_relative` and bare stdlib constant reference in `lib/` and `test/` against the gemspec, Gemfile, and Gemfile.lock, with a focus on the Ruby 3.4/3.5/4.0 default-gem-to-bundled-gem transition.

**No missing gem dependencies.** The only stdlib gems `lib/` requires are `erb` and `yaml` (psych). Both are still true default gems on Ruby 3.4 and neither appears in `Gem::BUNDLED_GEMS::SINCE`, so no `add_dependency` is warranted. Nothing in `lib/` touches a demoted gem (base64, bigdecimal, csv, drb, logger, ostruct, benchmark, irb, reline, etc.). `byebug` pulls in `reline` (bundled as of 4.0) but it is a declared dev dependency, so it resolves correctly.

**One real bug found:** `Pathname` is referenced in `Confg.calc_root_path` (`lib/confg.rb`) and `Configuration#initialize` (`lib/confg/configuration.rb`), but `pathname` is never required. It resolves today only because RubyGems loads `pathname` during boot. `pathname` is still a default gem, so this is a missing-require bug rather than a missing dependency — but it is the same class of latent breakage this audit targets.

Reproduced before the fix:

```
$ ruby --disable-gems -Ilib -e 'require "confg"; Confg.root'
lib/confg.rb:61:in 'Confg.calc_root_path': uninitialized constant Pathname (NameError)
```

## Changes

Added `require "pathname"` to the two files that use it, matching the existing convention in this repo of requiring stdlib at the point of use (`erb_context.rb` requires `erb`, `configuration.rb` requires `yaml`).

No gemspec, Gemfile, or Gemfile.lock changes — `pathname` is a default gem, so declaring it as a dependency would be wrong.

## Dependabot / Appraisal

No changes needed. `.github/dependabot.yml` already covers the bundler ecosystem with `dependency-type: all`, and no new declared dependency was added. There is no `Appraisals` file or `gemfiles/` directory in this repo.

## Test plan

- `bundle install` — clean, `Gemfile.lock` unchanged.
- `bundle exec rake` — 19 runs, 38 assertions, 0 failures, 0 errors, 0 skips.
- `ruby --disable-gems -Ilib -e 'require "confg"; Confg.root'` — now returns a `Pathname` instead of raising.
- No rubocop config in this repo, so none run.
