### PR TITLE
Bump patch version to 3.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    confg (3.4.1)
+    confg (3.4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -30,9 +30,9 @@ DEPENDENCIES
   rake
 
 CHECKSUMS
-  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
-  confg (3.4.1)
+  confg (3.4.2)
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
@@ -41,4 +41,4 @@ CHECKSUMS
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
 
 BUNDLED WITH
-  4.0.16
+  4.0.17

--- a/lib/confg/version.rb
+++ b/lib/confg/version.rb
@@ -4,7 +4,7 @@ module Confg
 
   MAJOR       = 3
   MINOR       = 4
-  PATCH       = 1
+  PATCH       = 2
   PRERELEASE  = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRERELEASE].compact.join(".")


### PR DESCRIPTION
Routine patch version bump (3.4.1 -> 3.4.2) plus bundler pin sync to 4.0.17 in Gemfile.lock.

Tests pass: 19 runs, 38 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)